### PR TITLE
grid-container: allow the grid to shrink to fit all avalible space to prevent sidescroll.

### DIFF
--- a/snippets/css/layouts/grid-layout.md
+++ b/snippets/css/layouts/grid-layout.md
@@ -9,7 +9,7 @@ tags: layout,grid
 ```css
 .grid-container {
   display: grid
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(250px, 100%), 1fr));
 /* Explanation:
 - `auto-fit`: Automatically fits as many columns as possible within the container.
 - `minmax(250px, 1fr)`: Defines a minimum column size of 250px and a maximum size of 1fr (fraction of available space).

--- a/snippets/css/layouts/grid-layout.md
+++ b/snippets/css/layouts/grid-layout.md
@@ -2,6 +2,7 @@
 title: Grid layout
 description: Equal sized items in a responsive grid
 author: xshubhamg
+contributors: tryoxiss
 tags: layout,grid
 ---
 

--- a/snippets/css/layouts/grid-layout.md
+++ b/snippets/css/layouts/grid-layout.md
@@ -8,7 +8,7 @@ tags: layout,grid
 
 ```css
 .grid-container {
-  display: grid
+  display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(250px, 100%), 1fr));
 /* Explanation:
 - `auto-fit`: Automatically fits as many columns as possible within the container.

--- a/snippets/css/layouts/grid-layout.md
+++ b/snippets/css/layouts/grid-layout.md
@@ -12,7 +12,8 @@ tags: layout,grid
   grid-template-columns: repeat(auto-fit, minmax(min(250px, 100%), 1fr));
 /* Explanation:
 - `auto-fit`: Automatically fits as many columns as possible within the container.
-- `minmax(250px, 1fr)`: Defines a minimum column size of 250px and a maximum size of 1fr (fraction of available space).
+- `minmax(min(250px, 100%), 1fr)`: Defines a minimum column size of 250px and a maximum size of 1fr (fraction of available space). However, that minimum column size is allowed to shrink to fit all avalible space if the space is otherwise less than the minimum.
+  - NOTE: the `min(x, 100%)` trick does not do much for very small sizes like 250px, but it will help massively if you increase the min column size yourself.
 */
 }
 ```


### PR DESCRIPTION
On some browsers, this has no effect on very small sizes such as 250px, since there is another limiting factor which prevents further shrinkage (e.g., word length). However this does work if the size is increased or the other limiting factors are removed.

<!-- **ANY PULL REQUEST NOT FOLLOWING GUIDELINES OR NOT INCLUDING A DESCRIPTION WILL BE CLOSED !** -->

# Description

This simply replaces `250px` with `min(250px, 100%)`. This makes it so that if not enough space is avalible, the grid will simply take up all avalible space instead of forcing horizontal scroll.

## Type of Change

<!-- What kind of change does this pull request introduce? (Check all that apply) -->

- [ ] :sparkles: New snippet
- [x] :tools: Improvement to an existing snippet
- [ ] :lady_beetle: Bug fix
- [ ] :book: Documentation update
- [ ] :wrench: Other (please describe):

## Checklist

<!--  Before submitting, ensure your pull request meets these requirements: -->

- [x] I have tested my code and verified it works as expected.
- [x] My code follows the style and contribution guidelines of this project.
- [x] Comments are added where necessary for clarity.
- [N/A] Documentation has been updated (if applicable).
- [N/A] There are no new warnings or errors from my changes.

## Related Issues

<!-- Link any relevant issues (use #issue-number syntax). If not, leave it empty -->

Closes #267 

## Additional Context

<!-- Add any extra details, questions, or considerations here. -->

## Screenshots (Optional)

(column width increased in demos for ease of demonstration)

Before:
![image](https://github.com/user-attachments/assets/c8c98ca9-a36b-4f98-8924-0e77a7ab5e99)

After:
![image](https://github.com/user-attachments/assets/b7542a6d-b7d1-4a4c-a350-87071b227915)

<!-- If your changes affect visuals, please include screenshots. -->

<details> 
<summary>Click to view screenshots</summary>

<!-- Add your screenshots here -->

</details>

EDIT: Update images so the viewport is exactly the same width