### PR TITLE
Change it so the categories endpoint is consistent by removing slugify

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -51,7 +51,7 @@ app.get("/languages", (_req, res) => {
 // Get all categories for a given language
 app.get("/categories/:language", (req, res) => {
   const { language } = req.params;
-  const file = path.join(dataDir, `consolidated/${slugify(language)}.json`);
+  const file = path.join(dataDir, `consolidated/${language}.json`);
   const json = readJSON(file);
 
   if (!json) {


### PR DESCRIPTION
<!-- **ANY PULL REQUEST NOT FOLLOWING GUIDELINES OR NOT INCLUDING A DESCRIPTION WILL BE CLOSED !** -->

# Description

This change removes the use of the `slugify` function from the categories endpoint when fetching the json data, as this is inconsistent with the rest of the endpoints, which do not do this step. 

## Type of Change

<!-- What kind of change does this pull request introduce? (Check all that apply) -->

- [ ] ✨ New snippet
- [ ] 🛠 Improvement to an existing snippet
- [x] 🐞 Bug fix
- [ ] 📖 Documentation update
- [ ] 🔧 Other (please describe):

## Checklist

<!--  Before submitting, ensure your pull request meets these requirements: -->

- [x] I have tested my code and verified it works as expected.
- [x] My code follows the style and contribution guidelines of this project.
- [x] Comments are added where necessary for clarity.
- [x] Documentation has been updated (if applicable).
- [x] There are no new warnings or errors from my changes.

## Related Issues

<!-- Link any relevant issues (use #issue-number syntax). If not, leave it empty -->

Closes #275 

## Additional Context

This was failing due to inconsistent rules regarding if the passed language is slugged or not. On snippets they're not slugged, thus simply removing this fixes the consistency problem.

Meaning, the current syntax to denote a sub-language (eg. `javascript--react`) was getting slugged like it was it's own language (eg. `javascript-react`). 
