### PR TITLE
[Feature] Added endpoint for retrieving snippets by category

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -48,6 +48,21 @@ app.get("/languages", (_req, res) => {
   return;
 });
 
+// Get all content (consolidated file) for language
+app.get("/languages/:language", (req, res) => {
+  const { language } = req.params;
+
+  const file = path.join(dataDir, `consolidated/${language}.json`);
+  const json = readJSON(file);
+  if (!json) {
+    res.status(404).json({ error: "Language file not found" });
+    return;
+  }
+
+  res.json(json);
+  return;
+});
+
 // Get all categories for a given language
 app.get("/categories/:language", (req, res) => {
   const { language } = req.params;


### PR DESCRIPTION
<!-- **ANY PULL REQUEST NOT FOLLOWING GUIDELINES OR NOT INCLUDING A DESCRIPTION WILL BE CLOSED !** -->

# Description

Since creating the new backend structure, snippets are no longer organized by category. The Raycast extension - which relies on this feature - had to remove a feature because of this.

This pull request aims to create a new endpoint which works like the previous version before this breaking change.

I'm creating a new endpoint to avoid causing breaking changes to existing code on the frontend, since I'm not quite sure how the API is used there.

<!-- Include a summary of your changes. -->

- Added new endpoint at /languages/:language

## Type of Change

<!-- What kind of change does this pull request introduce? (Check all that apply) -->

- [ ] ✨ New snippet
- [ ] 🛠 Improvement to an existing snippet
- [ ] 🐞 Bug fix
- [ ] 📖 Documentation update
- [x] 🔧 Other (please describe): New backend endpoint

## Checklist

<!--  Before submitting, ensure your pull request meets these requirements: -->

- [x] I have tested my code and verified it works as expected.
- [x] My code follows the style and contribution guidelines of this project.
- [x] Comments are added where necessary for clarity.
- [x] Documentation has been updated (if applicable).
- [x] There are no new warnings or errors from my changes.

## Related Issues

<!-- Link any relevant issues (use #issue-number syntax). If not, leave it empty -->

## Additional Context

<!-- Add any extra details, questions, or considerations here. -->

## Screenshots (Optional)

<!-- If your changes affect visuals, please include screenshots. -->

